### PR TITLE
HH-113853 refactor dangerous Publisher methods and fix integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ Use the following command to run tests:
 mvn-hh install -P test
 ```
 
+#### Example
+ - Deploy two rabbits locally:
+ ```
+docker run -d -p 15673:15672 -p 5673:5672 --name rabbit-1 rabbitmq:3-management
+docker run -d -p 15674:15672 -p 5674:5672 --name rabbit-2 rabbitmq:3-management
+```
+- Run tests with custom rabbit hosts and ports:
+```
+mvn-hh install -P test -Drabbit.integrationtest.host1=localhost -Drabbit.integrationtest.port1=5673 -Drabbit.integrationtest.host2=localhost -Drabbit.integrationtest.port2=5674
+```
+
 # MDC
 
 If following property is set:

--- a/rabbitmq-client/pom.xml
+++ b/rabbitmq-client/pom.xml
@@ -125,6 +125,14 @@
             <scope>test</scope>
             <version>1.1.3</version>
         </dependency>
+
+        <!-- https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <scope>test</scope>
+            <version>2.3.3</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/rabbitmq-client/src/main/java/ru/hh/rabbitmq/spring/send/PublishTaskFuture.java
+++ b/rabbitmq-client/src/main/java/ru/hh/rabbitmq/spring/send/PublishTaskFuture.java
@@ -15,7 +15,7 @@ class PublishTaskFuture extends ForwardingFuture<Void> implements ListenableFutu
   private final SettableFuture<Void> future = SettableFuture.create();
   private Optional<Map<String, String>> mdcContext;
 
-  PublishTaskFuture(Destination destination, Collection<Object> messages) {
+  PublishTaskFuture(Destination destination, Collection<?> messages) {
     this.messages = messages.stream().collect(HashMap::new, (m, v) -> m.put(v, destination), HashMap::putAll);
   }
 

--- a/rabbitmq-client/src/main/java/ru/hh/rabbitmq/spring/send/Publisher.java
+++ b/rabbitmq-client/src/main/java/ru/hh/rabbitmq/spring/send/Publisher.java
@@ -8,7 +8,6 @@ import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterrup
 import static java.lang.System.currentTimeMillis;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -128,7 +127,7 @@ public class Publisher extends AbstractService {
   }
 
   /**
-   * Potentially blocking method, enqueues messages internally, waiting if necessary, throws exception if local queue is full.
+   * Potentially blocking method, enqueues message internally, waiting if necessary, throws exception if local queue is full.
    * <p>
    * Wrap message with {@link CorrelatedMessage} to attach {@link CorrelationData} for publisher confirms.
    * </p>
@@ -136,8 +135,8 @@ public class Publisher extends AbstractService {
    * @return ListenableFuture that gets completed after successful sending
    * @throws InterruptedException
    */
-  public ListenableFuture<Void> offer(long timeoutMs, Destination destination, Object... messages) throws InterruptedException {
-    return offer(timeoutMs, destination, Arrays.asList(messages));
+  public ListenableFuture<Void> offer(long timeoutMs, Destination destination, Object message) throws InterruptedException {
+    return offer(timeoutMs, destination, List.of(message));
   }
 
   /**
@@ -149,7 +148,7 @@ public class Publisher extends AbstractService {
    * @return ListenableFuture that gets completed after successful sending
    * @throws InterruptedException
    */
-  public ListenableFuture<Void> offer(long timeoutMs, Destination destination, Collection<Object> messages) throws InterruptedException {
+  public ListenableFuture<Void> offer(long timeoutMs, Destination destination, Collection<?> messages) throws InterruptedException {
     checkNotNull(destination, "Destination can't be null");
     PublishTaskFuture future = new PublishTaskFuture(destination, messages);
     offerFuture(future, timeoutMs);
@@ -176,7 +175,7 @@ public class Publisher extends AbstractService {
 
   /**
    * <p>
-   * Potentially blocking method, enqueues messages internally, waiting if necessary, throws exception if local queue is full.
+   * Potentially blocking method, enqueues message internally, waiting if necessary, throws exception if local queue is full.
    * </p>
    * <p>
    * Wrap message with {@link CorrelatedMessage} to attach {@link CorrelationData} for publisher confirms.
@@ -188,8 +187,8 @@ public class Publisher extends AbstractService {
    * @return ListenableFuture that gets completed after successful sending
    * @throws InterruptedException
    */
-  public ListenableFuture<Void> offer(long timeoutMs, Object... messages) throws InterruptedException {
-    return offer(timeoutMs, Arrays.asList(messages));
+  public ListenableFuture<Void> offer(long timeoutMs, Object message) throws InterruptedException {
+    return offer(timeoutMs, List.of(message));
   }
 
   /**
@@ -206,7 +205,7 @@ public class Publisher extends AbstractService {
    * @return ListenableFuture that gets completed after successful sending
    * @throws InterruptedException
    */
-  public ListenableFuture<Void> offer(long timeoutMs, Collection<Object> messages) throws InterruptedException {
+  public ListenableFuture<Void> offer(long timeoutMs, Collection<?> messages) throws InterruptedException {
     PublishTaskFuture future = new PublishTaskFuture(null, messages);
     offerFuture(future, timeoutMs);
     return future;
@@ -222,15 +221,15 @@ public class Publisher extends AbstractService {
   }
 
   /**
-   * Nonblocking method, enqueues messages internally, throws exception if local queue is full.
+   * Nonblocking method, enqueues message internally, throws exception if local queue is full.
    * <p>
    * Wrap message with {@link CorrelatedMessage} to attach {@link CorrelationData} for publisher confirms.
    * </p>
    *
    * @return ListenableFuture that gets completed after successful sending
    */
-  public ListenableFuture<Void> send(Destination destination, Object... messages) {
-    return send(destination, Arrays.asList(messages));
+  public ListenableFuture<Void> send(Destination destination, Object message) {
+    return send(destination, List.of((message)));
   }
 
   /**
@@ -241,7 +240,7 @@ public class Publisher extends AbstractService {
    *
    * @return ListenableFuture that gets completed after successful sending
    */
-  public ListenableFuture<Void> send(Destination destination, Collection<Object> messages) {
+  public ListenableFuture<Void> send(Destination destination, Collection<?> messages) {
     checkNotNull(destination, "Destination can't be null");
     PublishTaskFuture future = new PublishTaskFuture(destination, messages);
     addFuture(future);
@@ -267,7 +266,7 @@ public class Publisher extends AbstractService {
 
   /**
    * <p>
-   * Nonblocking method, enqueues messages internally, throws exception if local queue is full.
+   * Nonblocking method, enqueues message internally, throws exception if local queue is full.
    * </p>
    * <p>
    * Wrap message with {@link CorrelatedMessage} to attach {@link CorrelationData} for publisher confirms.
@@ -278,8 +277,8 @@ public class Publisher extends AbstractService {
    *
    * @return ListenableFuture that gets completed after successful sending
    */
-  public ListenableFuture<Void> send(Object... messages) {
-    return send(Arrays.asList(messages));
+  public ListenableFuture<Void> send(Object message) {
+    return send(List.of(message));
   }
 
   /**
@@ -295,7 +294,7 @@ public class Publisher extends AbstractService {
    *
    * @return ListenableFuture that gets completed after successful sending
    */
-  public ListenableFuture<Void> send(Collection<Object> messages) {
+  public ListenableFuture<Void> send(Collection<?> messages) {
     PublishTaskFuture future = new PublishTaskFuture(null, messages);
     addFuture(future);
     return future;

--- a/rabbitmq-client/src/test/java/ru/hh/rabbitmq/spring/AsyncRabbitIntegrationTestBase.java
+++ b/rabbitmq-client/src/test/java/ru/hh/rabbitmq/spring/AsyncRabbitIntegrationTestBase.java
@@ -5,19 +5,19 @@ import ru.hh.rabbitmq.spring.send.PublisherBuilder;
 
 public class AsyncRabbitIntegrationTestBase extends RabbitIntegrationTestBase {
 
-  protected static PublisherBuilder publisher(String host, boolean withDirections, int innerQueueSize) {
-    Properties properties = properties(host);
+  protected static PublisherBuilder publisher(String host, int port, boolean withDirections, int innerQueueSize) {
+    Properties properties = properties(host, port);
     properties.setProperty(ConfigKeys.PUBLISHER_INNER_QUEUE_SIZE, Integer.toString(innerQueueSize));
     return publisher(properties, withDirections, false);
   }
 
-  protected static PublisherBuilder publisher(String host, boolean withDirections) {
-    Properties properties = properties(host);
+  protected static PublisherBuilder publisher(String host, int port, boolean withDirections) {
+    Properties properties = properties(host, port);
     return publisher(properties, withDirections, false);
   }
 
-  protected static PublisherBuilder publisher(String host, boolean withDirections, boolean withConfirms) {
-    Properties properties = properties(host);
+  protected static PublisherBuilder publisher(String host, int port, boolean withDirections, boolean withConfirms) {
+    Properties properties = properties(host, port);
     return publisher(properties, withDirections, withConfirms);
   }
 
@@ -32,8 +32,8 @@ public class AsyncRabbitIntegrationTestBase extends RabbitIntegrationTestBase {
     return factory.createPublisherBuilder();
   }
 
-  protected static PublisherBuilder publisherMDC(String host) {
-    Properties properties = properties(host);
+  protected static PublisherBuilder publisherMDC(String host, int port) {
+    Properties properties = properties(host, port);
     appendDirections(properties);
     properties.setProperty(ConfigKeys.PUBLISHER_USE_MDC, "true");
     ClientFactory factory = new ClientFactory(properties);

--- a/rabbitmq-client/src/test/java/ru/hh/rabbitmq/spring/RabbitIntegrationTestBase.java
+++ b/rabbitmq-client/src/test/java/ru/hh/rabbitmq/spring/RabbitIntegrationTestBase.java
@@ -1,5 +1,8 @@
 package ru.hh.rabbitmq.spring;
 
+import com.rabbitmq.client.AMQP;
+import static com.rabbitmq.client.ConnectionFactory.DEFAULT_PASS;
+import static com.rabbitmq.client.ConnectionFactory.DEFAULT_USER;
 import java.util.Properties;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -10,17 +13,22 @@ import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import static ru.hh.rabbitmq.spring.ConfigKeys.HOSTS_PORT_SEPARATOR;
+import static ru.hh.rabbitmq.spring.ConfigKeys.HOSTS_SEPARATOR;
 
 public class RabbitIntegrationTestBase {
 
   public static String HOST1 = "localhost";
-  public static String HOST2 = "dev";
-  public static String[] HOSTS;
-  public static final String USERNAME = "guest";
-  public static final String PASSWORD = "guest";
+  public static int PORT1 = AMQP.PROTOCOL.PORT;
 
-  public static final String ROUTING_KEY1 = "routingkey1";
-  public static final String ROUTING_KEY2 = "routingkey2";
+  public static String HOST2 = "dev";
+  public static int PORT2 = AMQP.PROTOCOL.PORT;
+
+  public static final String USERNAME = DEFAULT_USER;
+  public static final String PASSWORD = DEFAULT_PASS;
+
+  public static final String ROUTING_KEY1 = "routing_key1";
+  public static final String ROUTING_KEY2 = "routing_key2";
   public static final String QUEUE1 = "hh-rabbit-client-spring-queue-1";
   public static final String QUEUE2 = "hh-rabbit-client-spring-queue-2";
   public static final String EXCHANGE = "hh-rabbit-client-spring-exchange";
@@ -28,40 +36,49 @@ public class RabbitIntegrationTestBase {
   @BeforeClass
   public static void beforeClass() {
     String host1 = System.getProperty("rabbit.integrationtest.host1");
+    String port1 = System.getProperty("rabbit.integrationtest.port1");
     String host2 = System.getProperty("rabbit.integrationtest.host2");
+    String port2 = System.getProperty("rabbit.integrationtest.port2");
+
     if (host1 != null) {
       HOST1 = host1;
+    }
+    if (port1 != null) {
+      PORT1 = Integer.parseInt(port1);
     }
     if (host2 != null) {
       HOST2 = host2;
     }
-    HOSTS = new String[] { HOST1, HOST2 };
-    for (String host : HOSTS) {
-      setUp(getConnectionFactory(host));
+    if (port2 != null) {
+      PORT2 = Integer.parseInt(port2);
     }
+    setUp(getConnectionFactory(HOST1, PORT1));
+    setUp(getConnectionFactory(HOST2, PORT2));
   }
 
   @AfterClass
   public static void afterClass() {
-    for (String host : HOSTS) {
-      tearDown(getConnectionFactory(host));
-    }
+    tearDown(getConnectionFactory(HOST1, PORT1));
+    tearDown(getConnectionFactory(HOST2, PORT2));
   }
 
   @Before
   public void purgeQueues() {
-    for (String host : HOSTS) {
-      CachingConnectionFactory connectionFactory = getConnectionFactory(host);
-      RabbitAdmin admin = new RabbitAdmin(connectionFactory);
-      admin.afterPropertiesSet();
-      if (admin.getQueueProperties(QUEUE1) != null) {
-        admin.purgeQueue(QUEUE1, false);
-      }
-      if (admin.getQueueProperties(QUEUE2) != null) {
-        admin.purgeQueue(QUEUE2, false);
-      }
-      connectionFactory.destroy();
+    purgeQueue(HOST1, PORT1);
+    purgeQueue(HOST2, PORT2);
+  }
+
+  private void purgeQueue(String host, int port) {
+    CachingConnectionFactory connectionFactory = getConnectionFactory(host, port);
+    RabbitAdmin admin = new RabbitAdmin(connectionFactory);
+    admin.afterPropertiesSet();
+    if (admin.getQueueProperties(QUEUE1) != null) {
+      admin.purgeQueue(QUEUE1, false);
     }
+    if (admin.getQueueProperties(QUEUE2) != null) {
+      admin.purgeQueue(QUEUE2, false);
+    }
+    connectionFactory.destroy();
   }
 
   private static void setUp(CachingConnectionFactory connectionFactory) {
@@ -93,9 +110,10 @@ public class RabbitIntegrationTestBase {
     connectionFactory.destroy();
   }
 
-  private static CachingConnectionFactory getConnectionFactory(String host) {
+  private static CachingConnectionFactory getConnectionFactory(String host, int port) {
     CachingConnectionFactory factory = new CachingConnectionFactory();
     factory.setHost(host);
+    factory.setPort(port);
     factory.setUsername(USERNAME);
     factory.setPassword(PASSWORD);
     return factory;
@@ -122,21 +140,21 @@ public class RabbitIntegrationTestBase {
 
   protected static Properties propertiesAllHosts() {
     Properties properties = baseProperties();
-    properties.setProperty(ConfigKeys.HOSTS, HOST1 + ConfigKeys.HOSTS_SEPARATOR + HOST2);
+    properties.setProperty(ConfigKeys.HOSTS, HOST1 + HOSTS_PORT_SEPARATOR + PORT1 + HOSTS_SEPARATOR + HOST2 + HOSTS_PORT_SEPARATOR + PORT2);
     return properties;
   }
 
-  protected static Properties properties(String host) {
+  protected static Properties properties(String host, int port) {
     Properties properties = baseProperties();
-    properties.setProperty(ConfigKeys.HOSTS, host);
+    properties.setProperty(ConfigKeys.HOSTS, host + HOSTS_PORT_SEPARATOR + port);
+    properties.setProperty(ConfigKeys.PORT, String.valueOf(port));
     return properties;
   }
 
-  protected static Properties appendDirections(Properties properties) {
+  protected static void appendDirections(Properties properties) {
     properties.setProperty(ConfigKeys.RECEIVER_QUEUES, QUEUE1);
     properties.setProperty(ConfigKeys.PUBLISHER_EXCHANGE, EXCHANGE);
     properties.setProperty(ConfigKeys.PUBLISHER_ROUTING_KEY, ROUTING_KEY1);
-    return properties;
   }
 
   protected static Receiver receiverAllHosts(boolean withDirections) {

--- a/rabbitmq-client/src/test/java/ru/hh/rabbitmq/spring/SyncRabbitIntegrationTest.java
+++ b/rabbitmq-client/src/test/java/ru/hh/rabbitmq/spring/SyncRabbitIntegrationTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -20,8 +19,8 @@ public class SyncRabbitIntegrationTest extends SyncRabbitIntegrationTestBase {
 
   @Test
   public void testDirectionsConfigured() throws InterruptedException {
-    SyncPublisher publisherHost1 = publisher(HOST1, true).withJsonMessageConverter().build();
-    SyncPublisher publisherHost2 = publisher(HOST2, true).withJsonMessageConverter().build();
+    SyncPublisher publisherHost1 = publisher(HOST1, PORT1, true).withJsonMessageConverter().build();
+    SyncPublisher publisherHost2 = publisher(HOST2, PORT2, true).withJsonMessageConverter().build();
     publisherHost1.startAsync();
     publisherHost2.startAsync();
 
@@ -52,8 +51,8 @@ public class SyncRabbitIntegrationTest extends SyncRabbitIntegrationTestBase {
   public void testDirectionsDeclared() throws InterruptedException {
     Destination destination = new Destination(EXCHANGE, ROUTING_KEY1);
 
-    SyncPublisher publisherHost1 = publisher(HOST1, false).withJsonMessageConverter().build();
-    SyncPublisher publisherHost2 = publisher(HOST2, false).withJsonMessageConverter().build();
+    SyncPublisher publisherHost1 = publisher(HOST1, PORT1, false).withJsonMessageConverter().build();
+    SyncPublisher publisherHost2 = publisher(HOST2, PORT2, false).withJsonMessageConverter().build();
     publisherHost1.startAsync();
     publisherHost2.startAsync();
 
@@ -85,7 +84,7 @@ public class SyncRabbitIntegrationTest extends SyncRabbitIntegrationTestBase {
     Destination destination1 = new Destination(EXCHANGE, ROUTING_KEY1);
     Destination destination2 = new Destination(EXCHANGE, ROUTING_KEY2);
 
-    SyncPublisher publisher = publisher(HOST1, false).withJsonMessageConverter().build();
+    SyncPublisher publisher = publisher(HOST1, PORT1, false).withJsonMessageConverter().build();
     publisher.startAsync();
 
     MessageHandler handler = new MessageHandler();
@@ -111,8 +110,8 @@ public class SyncRabbitIntegrationTest extends SyncRabbitIntegrationTestBase {
   }
 
   @Test(expected = IllegalStateException.class)
-  public void testStoppedPublisher() throws InterruptedException {
-    SyncPublisher publisher = publisher(HOST1, true).withJsonMessageConverter().build();
+  public void testStoppedPublisher() {
+    SyncPublisher publisher = publisher(HOST1, PORT1, true).withJsonMessageConverter().build();
     publisher.startAsync();
 
     publisher.stopSync();
@@ -124,9 +123,9 @@ public class SyncRabbitIntegrationTest extends SyncRabbitIntegrationTestBase {
   }
 
   @Test
-  public void testPublisherConfirms() throws InterruptedException, ExecutionException {
+  public void testPublisherConfirms() throws InterruptedException {
     TestConfirmCallback callback = new TestConfirmCallback();
-    SyncPublisher publisher = publisher(HOST2, true, true).withJsonMessageConverter().withConfirmCallback(callback).build();
+    SyncPublisher publisher = publisher(HOST2, PORT2, true, true).withJsonMessageConverter().withConfirmCallback(callback).build();
     publisher.startAsync();
 
     Map<String, Object> sentMessage = new HashMap<>();
@@ -143,15 +142,15 @@ public class SyncRabbitIntegrationTest extends SyncRabbitIntegrationTestBase {
     String callbackValue;
     callbackValue = callback.get();
     assertNotNull("first callback value must not be null", callbackValue);
-    assertTrue("first callback value not in original: " + callbackValue, data.values().contains(callbackValue));
+    assertTrue("first callback value not in original: " + callbackValue, data.containsValue(callbackValue));
 
     callbackValue = callback.get();
     assertNotNull("second callback value must not be null", callbackValue);
-    assertTrue("second callback value not in original: " + callbackValue, data.values().contains(callbackValue));
+    assertTrue("second callback value not in original: " + callbackValue, data.containsValue(callbackValue));
 
     callbackValue = callback.get();
     assertNotNull("third callback value must not be null", callbackValue);
-    assertTrue("third callback value not in original: " + callbackValue, data.values().contains(callbackValue));
+    assertTrue("third callback value not in original: " + callbackValue, data.containsValue(callbackValue));
 
     MessageHandler handler = new MessageHandler();
     Receiver receiver = receiverAllHosts(true).withJsonListener(handler).forQueues(QUEUE1).start();
@@ -165,11 +164,11 @@ public class SyncRabbitIntegrationTest extends SyncRabbitIntegrationTestBase {
 
   @Test
   public void testMDC() throws InterruptedException {
-    String MDCKey = "mdctestkey";
-    String MDCValue = "mdctestvalue";
+    String MDCKey = "mdc_test_key";
+    String MDCValue = "mdc_test_value";
 
     MDC.put(MDCKey, MDCValue);
-    SyncPublisher publisherHost1 = publisherMDC(HOST1).withJsonMessageConverter().build();
+    SyncPublisher publisherHost1 = publisherMDC(HOST1, PORT1).withJsonMessageConverter().build();
     publisherHost1.startAsync();
 
     MessageHandler handler = new MessageHandler(true);

--- a/rabbitmq-client/src/test/java/ru/hh/rabbitmq/spring/SyncRabbitIntegrationTestBase.java
+++ b/rabbitmq-client/src/test/java/ru/hh/rabbitmq/spring/SyncRabbitIntegrationTestBase.java
@@ -15,10 +15,10 @@ public abstract class SyncRabbitIntegrationTestBase extends RabbitIntegrationTes
   public static final long TIMEOUT_MILLIS = 5000;
 
   protected static class MessageHandler implements MapMessageListener {
-    private ArrayBlockingQueue<Map<String, Object>> queue = new ArrayBlockingQueue<>(100);
-    private ArrayBlockingQueue<Map<String, String>> mdcContextQueue = new ArrayBlockingQueue<>(100);
+    private final ArrayBlockingQueue<Map<String, Object>> queue = new ArrayBlockingQueue<>(100);
+    private final ArrayBlockingQueue<Map<String, String>> mdcContextQueue = new ArrayBlockingQueue<>(100);
 
-    private boolean useMDC;
+    private final boolean useMDC;
 
     public MessageHandler() {
       this.useMDC = false;
@@ -46,9 +46,8 @@ public abstract class SyncRabbitIntegrationTestBase extends RabbitIntegrationTes
   }
 
   protected static class TestConfirmCallback implements ConfirmCallback {
-    private ArrayBlockingQueue<String> queue = new ArrayBlockingQueue<>(3);
+    private final ArrayBlockingQueue<String> queue = new ArrayBlockingQueue<>(3);
 
-    @SuppressWarnings("unused")
     @Override
     public void confirm(CorrelationData correlationData, boolean ack, String cause) {
       queue.add(correlationData.getId());
@@ -59,13 +58,13 @@ public abstract class SyncRabbitIntegrationTestBase extends RabbitIntegrationTes
     }
   }
 
-  protected static SyncPublisherBuilder publisher(String host, boolean withDirections) {
-    Properties properties = properties(host);
+  protected static SyncPublisherBuilder publisher(String host, int port, boolean withDirections) {
+    Properties properties = properties(host, port);
     return publisher(properties, withDirections, false);
   }
 
-  protected static SyncPublisherBuilder publisher(String host, boolean withDirections, boolean withConfirms) {
-    Properties properties = properties(host);
+  protected static SyncPublisherBuilder publisher(String host, int port, boolean withDirections, boolean withConfirms) {
+    Properties properties = properties(host, port);
     return publisher(properties, withDirections, withConfirms);
   }
 
@@ -80,8 +79,8 @@ public abstract class SyncRabbitIntegrationTestBase extends RabbitIntegrationTes
     return factory.createSyncPublisherBuilder();
   }
 
-  protected static SyncPublisherBuilder publisherMDC(String host) {
-    Properties properties = properties(host);
+  protected static SyncPublisherBuilder publisherMDC(String host, int port) {
+    Properties properties = properties(host, port);
     appendDirections(properties);
     properties.setProperty(ConfigKeys.PUBLISHER_USE_MDC, "true");
     ClientFactory factory = new ClientFactory(properties);


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-113853
Удалил варарги Object-ов в методах Publisher-а, добавил wildcard где необходимо. 
Доработка связана с задачей https://jira.hh.ru/browse/HH-113830
Также:
- Починил тесты
- Добавил возможность указывать кастомные порты для тестовых рэббитов
- Расширил тест отправки SimpleMessage